### PR TITLE
Feature/multi_source_auth

### DIFF
--- a/dotnet/build_jobs.yml
+++ b/dotnet/build_jobs.yml
@@ -8,9 +8,9 @@ jobs:
         packageType: sdk
         useGlobalJson: true
 
-    - script: |
-        dotnet nuget update source "${{ parameters.source }}" -u "vsts" -p "$(System.AccessToken)" --store-password-in-clear-text --configfile ./nuget.config
-      displayName: Authenticate with Azure DevOps NuGet Feed
+    - template: ../dotnetcommon/dotnet_auth.yml
+      parameters:
+        sources: ${{ parameters.sources }}
 
     - ${{ if eq(parameters.packAsTool, true) }}:
       - script: dotnet build src /p:Version=$(Build.BuildNumber) /p:PackAsTool=true /p:ToolCommandName=dotnet-helloworld

--- a/dotnet/build_stages.yml
+++ b/dotnet/build_stages.yml
@@ -8,7 +8,7 @@ stages:
             parameters:
               name: ${{ environment.name }}
               env: ${{ environment.env }}
-              source: ${{ parameters.sources }}
+              sources: ${{ parameters.sources }}
               packAsTool: ${{ parameters.packAsTool }}
               skipTests: ${{ parameters.skipTests }}
               toolCommandName: ${{ parameters.toolCommandName }}

--- a/dotnet/build_stages.yml
+++ b/dotnet/build_stages.yml
@@ -8,7 +8,7 @@ stages:
             parameters:
               name: ${{ environment.name }}
               env: ${{ environment.env }}
-              source: ${{ parameters.source }}
+              source: ${{ parameters.sources }}
               packAsTool: ${{ parameters.packAsTool }}
               skipTests: ${{ parameters.skipTests }}
               toolCommandName: ${{ parameters.toolCommandName }}

--- a/dotnetcommon/dotnet_auth.yml
+++ b/dotnetcommon/dotnet_auth.yml
@@ -1,0 +1,5 @@
+steps:
+- ${{ each source in parameters.sources }}:
+  - script: |
+      dotnet nuget update source "${{ source.name }}" -u "vsts" -p "${{ coalesce(source.token, '', '$(System.AccessToken)') }}" --store-password-in-clear-text --configfile ./nuget.config
+    displayName: Authenticate with Azure DevOps NuGet Feed


### PR DESCRIPTION
Usage example:

Old syntax:

```
stages:
- template: dotnet/stages.yml@templates
  parameters:
    shouldPush: eq(variables['Build.SourceBranch'], 'refs/heads/main')
    source: 'wcom-intern-ecdevops'
    packAsTool: true
    skipTests: true
    publishAsZip: false
    toolCommandName: 'dotnet-helloworld'
    build: Development
    environments:
      - env: dev
        name: Development
```

New Syntax:

```
stages:
- template: dotnet/stages.yml@templates
  parameters:
    shouldPush: eq(variables['Build.SourceBranch'], 'refs/heads/main')
   sources:
      - name: wcom-intern-ecdevops
      - name: third-party-feed
        token: $(THIRD_PARTY_ACCESS_TOKEN)
    packAsTool: true
    skipTests: true
    publishAsZip: false
    toolCommandName: 'dotnet-helloworld'
    build: Development
    environments:
      - env: dev
        name: Development
``` 

If you do not enter a specific token, the new auth will default to System.AccessToken