### PR TITLE
Add post-build script support to dotnet template

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -73,6 +73,21 @@ Azure DevOps Pipelines YAML template used to build, test, pack, and publish .NET
  env            | array    | Yes          |                   | The target environment.
  name           | string   | Yes          |                   | The target environment name.
 
+## Post-Build
+
+ **Parameters**   | **Type** | **Required** | **Default value** | **Description**
+------------------|----------|--------------|-------------------|----------------------------------
+ scriptType       | string   | No           |                   | The type of script. pscore or bash.
+ targetType       | string   | No           | filePath          | Specifies the type of script for the task to run. inline or filePath.
+ filePath         | string   | No           |                   | The path of the script.
+ script           | string   | No           |                   | The contents of the script. Supports either a loose file or inline script depending on the targetType.
+ arguments        | string   | No           |                   | Specifies the arguments passed to the script.
+ failOnStderr     | bool     | No           | false             | Fails task if errors are written to the error pipeline or if any data is written to the Standard Error stream.
+ showWarnings     | bool     | No           | false             | Show warnings in pipeline logs.
+ workingDirectory | string   | No           |                   | The working directory where the script is run.
+ bashEnvValue     | string   | No           |                   | Value for BASH_ENV environment variable.
+ pwsh             | bool     | No           | false             | Use PowerShell Core.
+
 ## Examples
 
 ### Minimum needed

--- a/dotnet/build_jobs.yml
+++ b/dotnet/build_jobs.yml
@@ -35,6 +35,10 @@ jobs:
     - script: dotnet pack ${{ parameters.projectSrc }} --no-build --no-restore --output "$(build.artifactstagingdirectory)" /p:Version=$(Build.BuildNumber) ${{ join(' ', parameters.buildParameters) }}
       displayName: 'DotNet Package'
 
+    - template: ../dotnetcommon/postbuild_common.yml
+      parameters:
+        postBuildScript: ${{ parameters.postBuildScript }}
+
     - task: PublishPipelineArtifact@1
       displayName: 'Publish ${{ parameters.artifactNamePrefix }}$(Build.DefinitionName) Artifact'
       inputs:

--- a/dotnetcommon/postbuild_common.yml
+++ b/dotnetcommon/postbuild_common.yml
@@ -1,0 +1,28 @@
+steps:
+- ${{ if in(parameters.postBuildScript.scriptType, 'pscore', 'bash') }}:
+  - ${{ if eq(parameters.postBuildScript.scriptType, 'pscore') }}:
+    - task: Powershell@2
+      displayName: Post-Build Powershell Script
+      inputs:
+        targetType: ${{ parameters.postBuildScript.targetType }}
+        filePath: ${{ parameters.postBuildScript.filePath }}
+        script: ${{ parameters.postBuildScript.script }}
+        arguments: ${{ parameters.postBuildScript.arguments }}
+        failOnStderr: ${{ parameters.postBuildScript.failOnStderr }}
+        showWarnings: ${{ parameters.postBuildScript.showWarnings }}
+        pwsh: ${{ parameters.postBuildScript.pwsh }}
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+  - ${{ if eq(parameters.postBuildScript.scriptType, 'bash') }}:
+    - task: Bash@3
+      displayName: Post-Build Bash Script
+      inputs:
+        targetType: ${{ parameters.postBuildScript.targetType }}
+        filePath: ${{ parameters.postBuildScript.filePath }}
+        script: ${{ parameters.postBuildScript.script }}
+        arguments: ${{ parameters.postBuildScript.arguments }}
+        failOnStderr: ${{ parameters.postBuildScript.failOnStderr }}
+        workingDirectory: ${{ parameters.postBuildScript.workingDirectory }}
+        bashEnvValue: ${{ parameters.postBuildScript.bashEnvValue }}
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken) 


### PR DESCRIPTION
- Introduced a new postBuildScript parameter in the pipeline configuration to allow execution of scripts after the build process.
- Created postbuild_common.yml to define the post-build script execution logic, supporting both PowerShell and Bash scripts.
- Updated build_jobs.yml to include the post-build script step before publishing artifacts.
- Documented the postBuildScript parameters in README.md to guide users on how to configure post-build scripts.