### PR TITLE
Enhance post-build script with custom environment variables

### DIFF
--- a/dotnetcommon/postbuild_common.yml
+++ b/dotnetcommon/postbuild_common.yml
@@ -13,6 +13,8 @@ steps:
         pwsh: ${{ parameters.postBuildScript.pwsh }}
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        ${{ each var in parameters.postBuildScript.env }}:
+          ${{ var.key }}: ${{ var.value }}
   - ${{ if eq(parameters.postBuildScript.scriptType, 'bash') }}:
     - task: Bash@3
       displayName: Post-Build Bash Script
@@ -25,4 +27,6 @@ steps:
         workingDirectory: ${{ parameters.postBuildScript.workingDirectory }}
         bashEnvValue: ${{ parameters.postBuildScript.bashEnvValue }}
       env:
-        SYSTEM_ACCESSTOKEN: $(System.AccessToken) 
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        ${{ each var in parameters.postBuildScript.env }}:
+          ${{ var.key }}: ${{ var.value }}


### PR DESCRIPTION
- Updated `postbuild_common.yml` to allow passing custom environment variables to both PowerShell and Bash post-build scripts.
- Added support for specifying additional environment variables through the `postBuildScript.env` parameter.