### PR TITLE
refactor: consolidate pre/post build scripts into common template

### DIFF
--- a/dotnetcommon/build_script.yml
+++ b/dotnetcommon/build_script.yml
@@ -1,0 +1,55 @@
+parameters:
+  script: {}
+  prefix: ''  # This will be either 'Pre-Build' or 'Post-Build'
+
+steps:
+- ${{ if in(parameters.script.scriptType, 'pscore', 'bash') }}:
+  - ${{ if parameters.script.azureSubscription }}:
+    - task: AzureCLI@2
+      displayName: ${{ coalesce(parameters.script.displayName, format('{0} Azure {1} {2} script', parameters.prefix, parameters.script.scriptType, parameters.script.targetType)) }}
+      inputs:
+        azureSubscription: ${{ parameters.script.azureSubscription }}
+        scriptType: ${{ parameters.script.scriptType }}
+        scriptLocation: ${{ replace(replace(parameters.script.targetType, 'filePath', 'scriptPath'), 'inline', 'inlineScript') }}
+        scriptPath: ${{ parameters.script.filePath }}
+        inlineScript: ${{ parameters.script.script }}
+        arguments: ${{ parameters.script.arguments }}
+        failOnStandardError: ${{ parameters.script.failOnStderr }}
+        workingDirectory: ${{ parameters.script.workingDirectory }}
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        ${{ each var in parameters.script.env }}:
+          ${{ var.key }}: ${{ var.value }}
+
+  - ${{ else }}:
+    - ${{ if eq(parameters.script.scriptType, 'pscore') }}:
+      - task: Powershell@2
+        displayName: ${{ coalesce(parameters.script.displayName, format('{0} PowerShell {1} script', parameters.prefix, parameters.script.targetType)) }}
+        inputs:
+          targetType: ${{ parameters.script.targetType }}
+          filePath: ${{ parameters.script.filePath }}
+          script: ${{ parameters.script.script }}
+          arguments: ${{ parameters.script.arguments }}
+          failOnStderr: ${{ parameters.script.failOnStderr }}
+          showWarnings: ${{ parameters.script.showWarnings }}
+          pwsh: ${{ parameters.script.pwsh }}
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          ${{ each var in parameters.script.env }}:
+            ${{ var.key }}: ${{ var.value }}
+
+    - ${{ if eq(parameters.script.scriptType, 'bash') }}:
+      - task: Bash@3
+        displayName: ${{ coalesce(parameters.script.displayName, format('{0} Bash {1} script', parameters.prefix, parameters.script.targetType)) }}
+        inputs:
+          targetType: ${{ parameters.script.targetType }}
+          filePath: ${{ parameters.script.filePath }}
+          script: ${{ parameters.script.script }}
+          arguments: ${{ parameters.script.arguments }}
+          failOnStderr: ${{ parameters.script.failOnStderr }}
+          workingDirectory: ${{ parameters.script.workingDirectory }}
+          bashEnvValue: ${{ parameters.script.bashEnvValue }}
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          ${{ each var in parameters.script.env }}:
+            ${{ var.key }}: ${{ var.value }} 

--- a/dotnetcommon/postbuild_common.yml
+++ b/dotnetcommon/postbuild_common.yml
@@ -1,51 +1,8 @@
+parameters:
+  postBuildScript: {}
+
 steps:
-- ${{ if in(parameters.postBuildScript.scriptType, 'pscore', 'bash') }}:
-  - ${{ if parameters.postBuildScript.azureSubscription }}:
-    - task: AzureCLI@2
-      displayName: ${{ coalesce(parameters.postBuildScript.displayName, format('Post-Build Azure {0} {1} script', parameters.postBuildScript.scriptType, parameters.postBuildScript.targetType)) }}
-      inputs:
-        azureSubscription: ${{ parameters.postBuildScript.azureSubscription }}
-        scriptType: ${{ parameters.postBuildScript.scriptType }}
-        scriptLocation: ${{ replace(replace(parameters.postBuildScript.targetType, 'filePath', 'scriptPath'), 'inline', 'inlineScript') }}
-        scriptPath: ${{ parameters.postBuildScript.filePath }}
-        inlineScript: ${{ parameters.postBuildScript.script }}
-        arguments: ${{ parameters.postBuildScript.arguments }}
-        failOnStandardError: ${{ parameters.postBuildScript.failOnStderr }}
-        workingDirectory: ${{ parameters.postBuildScript.workingDirectory }}
-      env:
-        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-        ${{ each var in parameters.postBuildScript.env }}:
-          ${{ var.key }}: ${{ var.value }}
-
-  - ${{ else }}:
-    - ${{ if eq(parameters.postBuildScript.scriptType, 'pscore') }}:
-      - task: Powershell@2
-        displayName: ${{ coalesce(parameters.postBuildScript.displayName, format('Post-Build PowerShell {0} script', parameters.postBuildScript.targetType)) }}
-        inputs:
-          targetType: ${{ parameters.postBuildScript.targetType }}
-          filePath: ${{ parameters.postBuildScript.filePath }}
-          script: ${{ parameters.postBuildScript.script }}
-          arguments: ${{ parameters.postBuildScript.arguments }}
-          failOnStderr: ${{ parameters.postBuildScript.failOnStderr }}
-          showWarnings: ${{ parameters.postBuildScript.showWarnings }}
-          pwsh: ${{ parameters.postBuildScript.pwsh }}
-        env:
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-          ${{ each var in parameters.postBuildScript.env }}:
-            ${{ var.key }}: ${{ var.value }}
-
-    - ${{ if eq(parameters.postBuildScript.scriptType, 'bash') }}:
-      - task: Bash@3
-        displayName: ${{ coalesce(parameters.postBuildScript.displayName, format('Post-Build Bash {0} script', parameters.postBuildScript.targetType)) }}
-        inputs:
-          targetType: ${{ parameters.postBuildScript.targetType }}
-          filePath: ${{ parameters.postBuildScript.filePath }}
-          script: ${{ parameters.postBuildScript.script }}
-          arguments: ${{ parameters.postBuildScript.arguments }}
-          failOnStderr: ${{ parameters.postBuildScript.failOnStderr }}
-          workingDirectory: ${{ parameters.postBuildScript.workingDirectory }}
-          bashEnvValue: ${{ parameters.postBuildScript.bashEnvValue }}
-        env:
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-          ${{ each var in parameters.postBuildScript.env }}:
-            ${{ var.key }}: ${{ var.value }}
+- template: build_script.yml
+  parameters:
+    script: ${{ parameters.postBuildScript }}
+    prefix: 'Post-Build'

--- a/dotnetcommon/prebuild_common.yml
+++ b/dotnetcommon/prebuild_common.yml
@@ -1,28 +1,8 @@
+parameters:
+  preBuildScript: {}
+
 steps:
-- ${{ if in(parameters.preBuildScript.scriptType, 'pscore', 'bash') }}:
-  - ${{ if eq(parameters.preBuildScript.scriptType, 'pscore') }}:
-    - task: Powershell@2
-      displayName: Pre-Build Powershell Script
-      inputs:
-        targetType: ${{ parameters.preBuildScript.targetType }}
-        filePath: ${{ parameters.preBuildScript.filePath }}
-        script: ${{ parameters.preBuildScript.script }}
-        arguments: ${{ parameters.preBuildScript.arguments }}
-        failOnStderr: ${{ parameters.preBuildScript.failOnStderr }}
-        showWarnings: ${{ parameters.preBuildScript.showWarnings }}
-        pwsh: ${{ parameters.preBuildScript.pwsh }}
-      env:
-        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-  - ${{ if eq(parameters.preBuildScript.scriptType, 'bash') }}:
-    - task: Bash@3
-      displayName: Pre-Build Bash Script
-      inputs:
-        targetType: ${{ parameters.preBuildScript.targetType }}
-        filePath: ${{ parameters.preBuildScript.filePath }}
-        script: ${{ parameters.preBuildScript.script }}
-        arguments: ${{ parameters.preBuildScript.arguments }}
-        failOnStderr: ${{ parameters.preBuildScript.failOnStderr }}
-        workingDirectory: ${{ parameters.preBuildScript.workingDirectory }}
-        bashEnvValue: ${{ parameters.preBuildScript.bashEnvValue }}
-      env:
-        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+- template: build_script.yml
+  parameters:
+    script: ${{ parameters.preBuildScript }}
+    prefix: 'Pre-Build'


### PR DESCRIPTION
Create a new build_script.yml template to reduce code duplication between prebuild_common.yml and postbuild_common.yml. The new template handles both pre-build and post-build scenarios through parameterization.

Key changes:
- Extract common script logic into build_script.yml
- Add prefix parameter to differentiate between pre/post build displays
- Simplify prebuild and postbuild files to use the common template
- Maintain all existing functionality while reducing code duplication