### PR TITLE
Pass publishEnvironmentVariables to container image build

### DIFF
--- a/container/build_step.yml
+++ b/container/build_step.yml
@@ -15,6 +15,9 @@ steps:
     env:
       DOTNET_CONTAINER_PULL_REGISTRY_UNAME: ${{ parameters.pullRegistryUsername }}
       DOTNET_CONTAINER_PULL_REGISTRY_PWORD: ${{ parameters.pullRegistryPassword }}
+      ${{ if parameters.publishEnvironmentVariables }}:
+        ${{ each envVar in parameters.publishEnvironmentVariables }}:
+          ${{ envVar.key }}: ${{ envVar.value }}
 
   - publish: "$(build.artifactstagingdirectory)/${{ parameters.artifact }}/${{ parameters.repository }}.tar.gz"
     displayName: 'Publish ${{ parameters.artifact }} Image'

--- a/container/build_steps.yml
+++ b/container/build_steps.yml
@@ -10,3 +10,4 @@ steps:
         tag: ${{ coalesce(parameters.container.tag, '$(Build.BuildNumber)') }}
         pullRegistryUsername: ${{ parameters.container.pullRegistryUsername }}
         pullRegistryPassword: ${{ parameters.container.pullRegistryPassword }}
+        publishEnvironmentVariables: ${{ parameters.publishEnvironmentVariables }}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.401",
+    "version": "10.0.300",
     "allowPrerelease": false,
     "rollForward": "feature"
   }

--- a/tests/integration/global.json
+++ b/tests/integration/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.401",
+    "version": "10.0.300",
     "allowPrerelease": false,
     "rollForward": "feature"
   }

--- a/tests/integration/src/dotnet/library/global.json
+++ b/tests/integration/src/dotnet/library/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.401",
+    "version": "10.0.300",
     "allowPrerelease": false,
     "rollForward": "feature"
   }

--- a/tests/integration/src/dotnet/library/library.tests/library.tests.csproj
+++ b/tests/integration/src/dotnet/library/library.tests/library.tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,14 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
-    <PackageReference Include="NUnit" Version="4.2.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/integration/src/dotnet/library/library/library.csproj
+++ b/tests/integration/src/dotnet/library/library/library.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tests/integration/src/dotnet/tool/global.json
+++ b/tests/integration/src/dotnet/tool/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.401",
+    "version": "10.0.300",
     "allowPrerelease": false,
     "rollForward": "feature"
   }

--- a/tests/integration/src/dotnet/tool/tool.csproj
+++ b/tests/integration/src/dotnet/tool/tool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tests/integration/src/dotnet/web/global.json
+++ b/tests/integration/src/dotnet/web/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.401",
+    "version": "10.0.300",
     "allowPrerelease": false,
     "rollForward": "feature"
   }

--- a/tests/integration/src/dotnet/web/web.csproj
+++ b/tests/integration/src/dotnet/web/web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/tests/integration/src/sql/DevOps/DevOps.sqlproj
+++ b/tests/integration/src/sql/DevOps/DevOps.sqlproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build">
-  <Sdk Name="Microsoft.Build.Sql" Version="0.1.9-preview" />
+  <Sdk Name="Microsoft.Build.Sql" Version="2.1.0" />
   <PropertyGroup>
     <DSP>Microsoft.Data.Tools.Schema.Sql.SqlAzureV12DatabaseSchemaProvider</DSP>
     <ModelCollation>1035,CI</ModelCollation>

--- a/tests/integration/src/sql/global.json
+++ b/tests/integration/src/sql/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.401",
+    "version": "10.0.300",
     "allowPrerelease": false,
     "rollForward": "feature"
   }


### PR DESCRIPTION
Forward publishEnvironmentVariables from dotnetweb publish jobs through container/build_steps.yml into build_step.yml so the PublishContainer bash step receives the same optional env vars as the dotnet publish step.

- Merge publishEnvironmentVariables into the container build env block when set
- Plumb the parameter through build_steps.yml to build_step.yml